### PR TITLE
Inactive Window Appearance

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -15,13 +15,13 @@
  to change at any time
  ----------------------------------------- **/
 
-#define COLOR_KEY_START [NSColor colorWithDeviceRed:0.659 green:0.659 blue:0.659 alpha:1.00]
-#define COLOR_KEY_END [NSColor colorWithDeviceRed:0.812 green:0.812 blue:0.812 alpha:1.00]
-#define COLOR_KEY_BOTTOM [NSColor colorWithDeviceRed:0.318 green:0.318 blue:0.318 alpha:1.00]
+#define COLOR_MAIN_START [NSColor colorWithDeviceRed:0.659 green:0.659 blue:0.659 alpha:1.00]
+#define COLOR_MAIN_END [NSColor colorWithDeviceRed:0.812 green:0.812 blue:0.812 alpha:1.00]
+#define COLOR_MAIN_BOTTOM [NSColor colorWithDeviceRed:0.318 green:0.318 blue:0.318 alpha:1.00]
  
-#define COLOR_NOTKEY_START [NSColor colorWithDeviceRed:0.851 green:0.851 blue:0.851 alpha:1.00]
-#define COLOR_NOTKEY_END [NSColor colorWithDeviceRed:0.929 green:0.929 blue:0.929 alpha:1.00]
-#define COLOR_NOTKEY_BOTTOM [NSColor colorWithDeviceRed:0.600 green:0.600 blue:0.600 alpha:1.00]
+#define COLOR_NOTMAIN_START [NSColor colorWithDeviceRed:0.851 green:0.851 blue:0.851 alpha:1.00]
+#define COLOR_NOTMAIN_END [NSColor colorWithDeviceRed:0.929 green:0.929 blue:0.929 alpha:1.00]
+#define COLOR_NOTMAIN_BOTTOM [NSColor colorWithDeviceRed:0.600 green:0.600 blue:0.600 alpha:1.00]
 
 /** Corner clipping radius **/
 #define CORNER_CLIP_RADIUS 4.0
@@ -37,12 +37,12 @@
 @implementation INTitlebarView
 - (void)drawRect:(NSRect)dirtyRect
 {
-    BOOL key = [[self window] isKeyWindow];
+    BOOL drawsAsMainWindow = ([[self window] isMainWindow] && [[NSApplication sharedApplication] isActive]);
     NSRect drawingRect = [self bounds];
     drawingRect.size.height -= 1.0; // Decrease the height by 1.0px to show the highlight line at the top
     
-    NSColor *startColor = key ? COLOR_KEY_START : COLOR_NOTKEY_START;
-    NSColor *endColor = key ? COLOR_KEY_END : COLOR_NOTKEY_END;
+    NSColor *startColor = drawsAsMainWindow ? COLOR_MAIN_START : COLOR_NOTMAIN_START;
+    NSColor *endColor = drawsAsMainWindow ? COLOR_MAIN_END : COLOR_NOTMAIN_END;
     NSBezierPath *clipPath = [self clippingPathWithRect:drawingRect cornerRadius:CORNER_CLIP_RADIUS];
     [NSGraphicsContext saveGraphicsState];
     [clipPath addClip];
@@ -51,7 +51,7 @@
     [gradient release];
     [NSGraphicsContext restoreGraphicsState];
     
-    NSColor *bottomColor = key ? COLOR_KEY_BOTTOM : COLOR_NOTKEY_BOTTOM;
+    NSColor *bottomColor = drawsAsMainWindow ? COLOR_MAIN_BOTTOM : COLOR_NOTMAIN_BOTTOM;
     NSRect bottomRect = NSMakeRect(0.0, NSMinY(drawingRect), NSWidth(drawingRect), 1.0);
     [bottomColor set];
     NSRectFill(bottomRect);
@@ -100,6 +100,9 @@
 
 - (void)dealloc
 {
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidBecomeActiveNotification object:[NSApplication sharedApplication]];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidResignActiveNotification object:[NSApplication sharedApplication]];
+	
     [_titleBarView release];
     [super dealloc];
 }
@@ -183,6 +186,8 @@
     [self _createTitlebarView];
     [self _layoutTrafficLightsAndContent];
     
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_INAppStoreWindow_applicationDidToggleActive:) name:NSApplicationDidBecomeActiveNotification object:[NSApplication sharedApplication]];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_INAppStoreWindow_applicationDidToggleActive:) name:NSApplicationDidResignActiveNotification object:[NSApplication sharedApplication]];
 }
 
 - (void)_layoutTrafficLightsAndContent
@@ -237,5 +242,9 @@
         minTitleHeight = (frameRect.size.height - contentRect.size.height);
     }
     return minTitleHeight;
+}
+
+- (void)_INAppStoreWindow_applicationDidToggleActive:(NSNotification *)notification {
+	[_titleBarView setNeedsDisplay:YES];
 }
 @end


### PR DESCRIPTION
Hi Indragie,

thank you for your `INAppStoreWindow` class!

When trying it out, I realised the title bar gradient didn’t always match the default one from `NSWindow`. This is particularly true when you open a panel (like the standard about panel from _My App > About My App_). The trick is to use the inactive appearance when either `-[NSWindow isMainWindow]` or `-[NSApplication isActive]` returns `NO`. I’ve tried to get this right in my fork and I’m now asking you to pull this change into your repo so others can benefit from it as well.

Kind regards,
– Georg
