### PR TITLE
Fix to Traffic Light tracking area problem

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -293,19 +293,8 @@
 // Solution for tracking area issue thanks to @Perspx (Alex Rozanski) <https://gist.github.com/972958>
 - (void)_setupTrafficLightsTrackingArea
 {
-    NSView *themeFrame = [[self contentView] superview];
-    NSArray *trackingAreas = [themeFrame trackingAreas];
-    if (![trackingAreas count]) { return; } // safety in case there are no tracking areas
-    NSTrackingArea *trackingArea = [trackingAreas objectAtIndex:0];
-    NSRect closeFrame = [[self standardWindowButton:NSWindowCloseButton] frame];
-    // Alter the tracking area rectangle    
-    NSRect trackingRect = [trackingArea rect];
-    trackingRect.origin.y = NSMinY(closeFrame);
-    // Create the new tracking area and set it on the window's theme frame view
-    NSTrackingArea *newTrackingArea = [[NSTrackingArea alloc] initWithRect:trackingRect options:[trackingArea options] owner:[trackingArea owner] userInfo:[NSDictionary dictionary]];
-    [themeFrame removeTrackingArea:trackingArea];
-    [themeFrame addTrackingArea:newTrackingArea];
-    [newTrackingArea release];
+    [[[self contentView] superview] viewWillStartLiveResize];
+    [[[self contentView] superview] viewDidEndLiveResize];
 }
 
 - (void)_recalculateFrameForTitleBarView


### PR DESCRIPTION
This is a more reliable fix to the Traffic Light tracking area issue. I had trouble with the fix submitted by @Perspx, especially after upgrading to Lion. In my testing this fix works 100% of the time.
