### PR TITLE
Added a property to centre the traffic lights (vertically) or not. Defaults to YES (your original behaviour).

### DIFF
--- a/INAppStoreWindow.h
+++ b/INAppStoreWindow.h
@@ -22,11 +22,20 @@
  **/
 @interface INAppStoreWindow : NSWindow {
     CGFloat _titleBarHeight;
+	BOOL _centersTrafficWindowButtons;
     NSView *_titleBarView;
 	NSString *_windowMenuTitle;
 }
+
+
 /** The height of the title bar. By default, this is set to the standard title bar height. **/
 @property (nonatomic, assign) CGFloat titleBarHeight;
+
+
+/** Toggles whether or not the Window buttons should be centered in the title bar. Defaults to YES **/
+@property (nonatomic, assign) BOOL centersTrafficWindowButtons;
+
+
 /** The title bar view itself. Add subviews to this view that you want to show in the title bar (e.g. buttons, a toolbar, etc.). This view can also be set if you want to use a different styled title bar aside from the default one (textured, etc.). **/
 @property (nonatomic, retain) NSView *titleBarView;
 @end

--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -229,6 +229,26 @@
     return _titleBarHeight;
 }
 
+
+- (void)setCentersTrafficWindowButtons:(BOOL)centersTrafficWindowButtons
+{
+	if (_centersTrafficWindowButtons == centersTrafficWindowButtons)
+		return; // don't do any more work.
+	
+	_centersTrafficWindowButtons = centersTrafficWindowButtons;
+	
+	
+	// Update the display and tracking area of the traffic lights.
+	[self _layoutTrafficLightsAndContent];
+	[self _setupTrafficLightsTrackingArea];
+}
+
+
+- (BOOL)centersTrafficWindowButtons
+{
+	return _centersTrafficWindowButtons;
+}
+
 #pragma mark -
 #pragma mark Private
 
@@ -250,6 +270,10 @@
     
     [nc addObserver:self selector:@selector(_displayWindowAndTitlebar) name:NSApplicationDidBecomeActiveNotification object:nil];
     [nc addObserver:self selector:@selector(_displayWindowAndTitlebar) name:NSApplicationDidResignActiveNotification object:nil];
+	
+	
+	// Set the traffic lights to be centered
+	_centersTrafficWindowButtons = YES;
     
     [self _createTitlebarView];
     [self _layoutTrafficLightsAndContent];
@@ -259,21 +283,25 @@
 - (void)_layoutTrafficLightsAndContent
 {
     NSView *contentView = [self contentView];
-    NSButton *close = [self standardWindowButton:NSWindowCloseButton];
-    NSButton *minimize = [self standardWindowButton:NSWindowMiniaturizeButton];
-    NSButton *zoom = [self standardWindowButton:NSWindowZoomButton];
-    
-    // Set the frame of the window buttons
-    NSRect closeFrame = [close frame];
-    NSRect minimizeFrame = [minimize frame];
-    NSRect zoomFrame = [zoom frame];
-    float buttonOrigin = floor(NSMidY([_titleBarView frame]) - (closeFrame.size.height / 2.0));
-    closeFrame.origin.y = buttonOrigin;
-    minimizeFrame.origin.y = buttonOrigin;
-    zoomFrame.origin.y = buttonOrigin;
-    [close setFrame:closeFrame];
-    [minimize setFrame:minimizeFrame];
-    [zoom setFrame:zoomFrame];
+	
+	if (_centersTrafficWindowButtons)
+	{
+		NSButton *close = [self standardWindowButton:NSWindowCloseButton];
+		NSButton *minimize = [self standardWindowButton:NSWindowMiniaturizeButton];
+		NSButton *zoom = [self standardWindowButton:NSWindowZoomButton];
+		
+		// Set the frame of the window buttons
+		NSRect closeFrame = [close frame];
+		NSRect minimizeFrame = [minimize frame];
+		NSRect zoomFrame = [zoom frame];
+		float buttonOrigin = floor(NSMidY([_titleBarView frame]) - (closeFrame.size.height / 2.0));
+		closeFrame.origin.y = buttonOrigin;
+		minimizeFrame.origin.y = buttonOrigin;
+		zoomFrame.origin.y = buttonOrigin;
+		[close setFrame:closeFrame];
+		[minimize setFrame:minimizeFrame];
+		[zoom setFrame:zoomFrame];
+	}
     
     // Reposition the content view
     NSRect windowFrame = [self frame];


### PR DESCRIPTION
Added a BOOL property to control whether or not the Traffic lights are centred in the title bar. By default they will (retaining the original behaviour of this class), but they can be configured to pre-App Store state (i.e. glued to the top of the title bar).
