### PR TITLE
Add support for "Double-click on title bar to minimize"

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -134,6 +134,19 @@
     return path;
 }
 
+- (void)mouseUp:(NSEvent *)theEvent {
+    if ([theEvent clickCount] == 2) {
+        // Get settings from "System Preferences" >  "Appearance" > "Double-click on windows title bar to minimize"
+        NSString *const MDAppleMiniaturizeOnDoubleClickKey = @"AppleMiniaturizeOnDoubleClick";
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults addSuiteNamed:NSGlobalDomain];
+        BOOL shouldMiniaturize = [[userDefaults objectForKey:MDAppleMiniaturizeOnDoubleClickKey] boolValue];
+        if (shouldMiniaturize) {
+            [[self window] miniaturize:self];
+        }
+    }
+}
+
 @end
 
 @implementation INAppStoreWindow


### PR DESCRIPTION
There is an option in System Preferences.app so that a double click on the window title bar will minimize the window. Right now the title bar will not respect this option, so I added this to fix it.
