### PR TITLE
Redraw in becomeKeyWindow instead of makeKeyAndOrderFront, truly fixes #19

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -198,6 +198,11 @@
 	[super makeKeyAndOrderFront:sender];
 	if ( ![self isExcludedFromWindowsMenu] )
 		[NSApp addWindowsItem:self title:self.windowMenuTitle filename:NO];	
+}
+
+- (void)becomeKeyWindow
+{
+    [super becomeKeyWindow];
     [_titleBarView setNeedsDisplay:YES];
 }
 


### PR DESCRIPTION
Redraw the title bar view in becomeKeyWindow instead of makeKeyAndOrderFront because a window can become key without being ordered front.
