### PR TITLE
Align FullScreen button in Lion

### DIFF
--- a/INAppStoreWindow.h
+++ b/INAppStoreWindow.h
@@ -44,4 +44,5 @@
 @property (nonatomic) CGFloat titleBarHeight;
 /** The title bar view itself. Add subviews to this view that you want to show in the title bar (e.g. buttons, a toolbar, etc.). This view can also be set if you want to use a different styled title bar aside from the default one (textured, etc.). **/
 @property (INAppStoreWindowRetain) NSView *titleBarView;
+@property (nonatomic) BOOL centerFullScreenButon;
 @end

--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -160,7 +160,7 @@ static CGImageRef createNoiseImageRef(int width, int height, float factor)
 @implementation INAppStoreWindow
 
 @synthesize windowMenuTitle = _windowMenuTitle;
-
+@synthesize centerFullScreenButon=_centerFullScreenButon;
 #pragma mark -
 #pragma mark Initialization
 
@@ -347,6 +347,18 @@ static CGImageRef createNoiseImageRef(int width, int height, float factor)
     [minimize setFrame:minimizeFrame];
     [zoom setFrame:zoomFrame];
     
+    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+    // Set the frame of the FullScreen button in Lion if available
+    if ( IN_RUNNING_LION && _centerFullScreenButon ) {
+        NSButton *fullScreen = [self standardWindowButton:NSWindowFullScreenButton];
+        if( fullScreen )
+        {
+            NSRect fullScreenFrame = [fullScreen frame];
+            fullScreenFrame.origin.y=buttonOrigin;
+            [fullScreen setFrame:fullScreenFrame];
+        }
+    }
+    #endif
     // Reposition the content view
     NSRect windowFrame = [self frame];
     NSRect newFrame = [contentView frame];


### PR DESCRIPTION
- Added code to center vertically the window's fullScreen button in Lion.
- Included a new property to enable/disable it.  It allows to center the button (like Github for Mac or Reeder) or keep it the upper corner (like iTunes,Xcode..)
