### PR TITLE
Add an option to hide baseline separator for INTitlebarView.

### DIFF
--- a/INAppStoreWindow.h
+++ b/INAppStoreWindow.h
@@ -29,6 +29,7 @@
  Draws a default style Mac OS X title bar.
  **/
 @interface INTitlebarView : NSView
+@property (nonatomic) BOOL showsBaselineSeparator;
 - (NSBezierPath*)clippingPathWithRect:(NSRect)aRect cornerRadius:(CGFloat)radius;
 @end
 
@@ -41,6 +42,7 @@
 	NSString *_windowMenuTitle;
     BOOL _centerFullScreenButton;
     BOOL _hideTitleBarInFullScreen;
+    BOOL _showsBaselineSeparator;
     BOOL _centerTrafficLightButtons;
     CGFloat _cachedTitleBarHeight;
 	CGFloat _trafficLightButtonsLeftMargin;
@@ -56,6 +58,9 @@
 /** If you want to hide the title bar in fullscreen mode, set this boolean to YES **/
 @property (nonatomic) BOOL hideTitleBarInFullScreen;
 /** Adjust the left and right padding of the trafficlight and fullscreen buttons */
+@property (nonatomic) BOOL showsBaselineSeparator;
+/** Use this API to hide the baseline INAppStoreWindow draws between itself and the main window contents. */
 @property (nonatomic) CGFloat trafficLightButtonsLeftMargin;
 @property (nonatomic) CGFloat fullScreenButtonRightMargin;
+
 @end

--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -84,6 +84,16 @@ static CGImageRef createNoiseImageRef(NSUInteger width, NSUInteger height, CGFlo
 
 @implementation INTitlebarView
 
+@synthesize showsBaselineSeparator = _showsBaselineSeparator;
+
+- (id)initWithFrame:(NSRect)frameRect {
+    if (self = [super initWithFrame:frameRect]) {
+        _showsBaselineSeparator = YES;
+    }
+    
+    return self;
+}
+
 - (void)drawRect:(NSRect)dirtyRect
 {
     BOOL drawsAsMainWindow = ([[self window] isMainWindow] && [[NSApplication sharedApplication] isActive]);
@@ -116,20 +126,22 @@ static CGImageRef createNoiseImageRef(NSUInteger width, NSUInteger height, CGFlo
         [NSGraphicsContext restoreGraphicsState];
     }
     
-    NSColor *bottomColor = nil;
-    if (IN_RUNNING_LION) {
-        bottomColor = drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM_L : IN_COLOR_NOTMAIN_BOTTOM_L;
-    } else {
-        bottomColor = drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM : IN_COLOR_NOTMAIN_BOTTOM;
-    }
-    NSRect bottomRect = NSMakeRect(0.0, NSMinY(drawingRect), NSWidth(drawingRect), 1.0);
-    [bottomColor set];
-    NSRectFill(bottomRect);
-    
-    if (IN_RUNNING_LION) {
-        bottomRect.origin.y += 1.0;
-        [[NSColor colorWithDeviceWhite:1.0 alpha:0.12] setFill];
-        [[NSBezierPath bezierPathWithRect:bottomRect] fill];
+    if (_showsBaselineSeparator) {
+        NSColor *bottomColor = nil;
+        if (IN_RUNNING_LION) {
+          bottomColor = drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM_L : IN_COLOR_NOTMAIN_BOTTOM_L;
+        } else {
+          bottomColor = drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM : IN_COLOR_NOTMAIN_BOTTOM;
+        }
+        NSRect bottomRect = NSMakeRect(0.0, NSMinY(drawingRect), NSWidth(drawingRect), 1.0);
+        [bottomColor set];
+        NSRectFill(bottomRect);
+        
+        if (IN_RUNNING_LION) {
+          bottomRect.origin.y += 1.0;
+          [[NSColor colorWithDeviceWhite:1.0 alpha:0.12] setFill];
+          [[NSBezierPath bezierPathWithRect:bottomRect] fill];
+        }
     }
 }
 


### PR DESCRIPTION
The original idea is to clone the behavior of NSToolbar. 
This would be especially useful when integrate INAppStoreWindow with tab bar component such as PSMTabBarControl.
