### PR TITLE
Fixes the slightly broken readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The baseline divider can be hidden by setting `showsBaselineSeparator` to `NO`, 
 
 A lot of time and effort has gone into making the custom titlebar in INAppStoreWindow function just right, it would be a shame to have to re-implement all this work just to draw your own custom title bar. So INAppStoreWindow has a `titleBarDrawingBlock` property that can be set to a block containing your own drawing code!
 
-[![](http://dribbble.com/system/users/7253/screenshots/541256/notepad.png?1335943595)](http://dribbble.com/shots/541256-Notepad-App-Mockup)
+[![](http://dribbble.com/system/assets/2398/7253/screenshots/541256/notepad.png)](http://dribbble.com/shots/541256-Notepad-App-Mockup)
 
 ```obj-c
 [self.window setTitleBarDrawingBlock:^(BOOL drawsAsMainWindow, CGRect drawingRect, CGPathRef clippingPath){


### PR DESCRIPTION
Embedding an image in from dribbble isn't the best idea anyway, but this fixes the non-existant image.
