### PR TITLE
Fixed crash in createNoiseImageRef()

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -67,10 +67,10 @@ static inline CGImageRef createNoiseImageRef(NSUInteger width, NSUInteger height
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
     CGContextRef bitmapContext = 
     CGBitmapContextCreate(rgba, width, height, 8, width, colorSpace, kCGImageAlphaNone);
-    free(rgba);
-    CGColorSpaceRelease(colorSpace);
     CGImageRef image = CGBitmapContextCreateImage(bitmapContext);
     CFRelease(bitmapContext);
+    CGColorSpaceRelease(colorSpace);
+    free(rgba);
     return image;
 }
 


### PR DESCRIPTION
CGBitmapContextCreate() does not take ownership of the passed data
pointer, and free()'ing it while the context is around crashes the app.
