### PR TITLE
Disabled custom window movement when movably by window background.

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -279,6 +279,12 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 {
     NSWindow *window = [self window];
     NSPoint where =  [window convertBaseToScreen:[theEvent locationInWindow]];
+	
+	if ([window isMovableByWindowBackground]) {
+		[super mouseDragged: theEvent];
+		return;
+	}
+	
     NSPoint origin = [window frame].origin;
     while ((theEvent = [NSApp nextEventMatchingMask:NSLeftMouseDownMask | NSLeftMouseDraggedMask | NSLeftMouseUpMask untilDate:[NSDate distantFuture] inMode:NSEventTrackingRunLoopMode dequeue:YES]) && ([theEvent type] != NSLeftMouseUp)) {
         @autoreleasepool {


### PR DESCRIPTION
This custom movement code causes the window to be moved by the system as well as by the custom handler, causing flicker (at least in my app). Since it's not needed when the window is movable by window background anyway, I disabled it in those cases.
