### PR TITLE
Fixes an issue with autolayout and three-pane split view on Lion

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -383,7 +383,7 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
     [super setContentView:aView];
 
 #if IN_COMPILING_LION
-	if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_7)
+	if (IN_RUNNING_LION)
 		[self layoutIfNeeded];
 #endif
 	


### PR DESCRIPTION
When setting the frame size during setContentView, auto layout gets confused in some cases on Lion. 
