### PR TITLE
Do not use addSuiteNamed:

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -280,7 +280,6 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
         // Get settings from "System Preferences" >  "Appearance" > "Double-click on windows title bar to minimize"
         NSString *const MDAppleMiniaturizeOnDoubleClickKey = @"AppleMiniaturizeOnDoubleClick";
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        [userDefaults addSuiteNamed:NSGlobalDomain];
         BOOL shouldMiniaturize = [[userDefaults objectForKey:MDAppleMiniaturizeOnDoubleClickKey] boolValue];
         if (shouldMiniaturize) {
             [[self window] miniaturize:self];


### PR DESCRIPTION
This fixes the code introduced in  https://github.com/indragiek/INAppStoreWindow/commit/846615f75e550a4c7be0eb12d0cb0da1cfe52248.

By default, `NSUserDefaults` includes the global domain. Thus adding `NSGlobalDomain` is redundant and slow.
