### PR TITLE
Updated project file to use spaces, rather than tabs

### DIFF
--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 				03970EF61315CE4400F15C7E /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		03970EF61315CE4400F15C7E /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The code already uses spaces everywhere, but my Xcode defaults to tabs. This commit simply sets this Xcode project to override user’s default settings and use spaces correctly.
