### PR TITLE
Setting the style mask does not affect the windows layout as it should

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -713,6 +713,8 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
 	_preventWindowFrameChange = YES;
 	[super setStyleMask:styleMask];
 	_preventWindowFrameChange = NO;
+	
+	[self _layoutTrafficLightsAndContent];
 }
 
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag


### PR DESCRIPTION
The change in 3276cca0 that fixed a bug related to setting the window's style mask was preventing the window's layout from being properly updated.  One way this manifests itself is if a window needs to flip back and forth from having a titlebar and not having a titlebar.  When going from not having a title bar to having a title bar by setting the style mask, the window would resize it's content view correctly but the title bar area would just be a white rectangle.
