### PR TITLE
Made double-click miniaturize respect window settings

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -362,7 +362,7 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         BOOL shouldMiniaturize = [[userDefaults objectForKey:MDAppleMiniaturizeOnDoubleClickKey] boolValue];
         if (shouldMiniaturize) {
-            [[self window] miniaturize:self];
+            [[self window] performMiniaturize:self];
         }
     }
 }


### PR DESCRIPTION
Previously, if the window was set to not allow miniaturizing, double-clicking on the title would still work and miniaturize the window.

Using performMiniaturize: instead of miniaturize: seems to fix this and not allow miniturization when the window does not support it.
