### PR TITLE
Private content view class to speed up window resizing.

### DIFF
--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -512,10 +512,15 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
 
 - (void)setContentView:(NSView *)aView
 {
+	// Remove performance-optimized content view class when changing content views
+    NSView *oldView = [self contentView];
+	if (oldView && object_getClass(oldView) == [INAppStoreWindowContentView class])
+		object_setClass(oldView, [NSView class]);
+    
     [super setContentView:aView];
     
 	// Swap in performance-optimized content view class
-	if (object_getClass(aView) == [NSView class])
+	if (aView && object_getClass(aView) == [NSView class])
 		object_setClass(aView, [INAppStoreWindowContentView class]);
 	
     [self _repositionContentView];


### PR DESCRIPTION
In sampling the resizing performance of my app, I saw that a huge part of performance went down by NSWindow setting the "usual" content view size first only for INAppStoreWindow to reposition the content view later. This caused multiple invalidations of layout constraints and display states to happen.

I somewhat circumvent the problem by building a custom content view class that corrects frame set by the window and by that alleviates the need for INAppStore to "fix" the frame.

This patch lazily modifies the content view passed to the window and by that does not require any change of using INAppStoreWindow. It also preserves compatibility with non-NSView content view classes, where is falls back to the previous method.
