### PR TITLE
NSDoc / showsProxyIcon implementation

### DIFF
--- a/INAppStoreWindow.h
+++ b/INAppStoreWindow.h
@@ -108,7 +108,7 @@
  To draw title on your own, set this property to `NO` and draw title inside titleBarDrawingBlock. */
 @property (nonatomic) BOOL showsTitle;
 @property (nonatomic) BOOL showsTitleInFullscreen;
-@property (nonatomic) BOOL showsProxyIcon;
+@property (nonatomic) BOOL showsDocumentProxyIcon;
 
 /** 
  If not nil, default window buttons are hidden and the their provided alternatives is used. 

--- a/INAppStoreWindow.m
+++ b/INAppStoreWindow.m
@@ -419,7 +419,7 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
 @synthesize inactiveTitleBarStartColor = _inactiveTitleBarStartColor;
 @synthesize inactiveTitleBarEndColor = _inactiveTitleBarEndColor;
 @synthesize inactiveBaselineSeparatorColor = _inactiveBaselineSeparatorColor;
-@synthesize showsProxyIcon = _showsProxyIcon;
+@synthesize showsDocumentProxyIcon = _showsDocumentProxyIcon;
 
 #pragma mark -
 #pragma mark Initialization
@@ -443,7 +443,7 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
 - (void)setRepresentedURL:(NSURL *)url
 {
     [super setRepresentedURL:url];
-    if (_showsProxyIcon == NO) {
+    if (_showsDocumentProxyIcon == NO) {
         [[self standardWindowButton:NSWindowDocumentIconButton] setImage:nil];
     }
 }
@@ -611,9 +611,9 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
     }
 }
 
-- (void)setShowsProxyIcon:(BOOL)showsProxyIcon {
-    if (_showsProxyIcon != showsProxyIcon) {
-        _showsProxyIcon = showsProxyIcon;
+- (void)setShowsDocumentProxyIcon:(BOOL)showsDocumentProxyIcon {
+    if (_showsDocumentProxyIcon != showsDocumentProxyIcon) {
+        _showsDocumentProxyIcon = showsDocumentProxyIcon;
         [self _displayWindowAndTitlebar];
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please refer to `INWindowButton.h` header documentation for more details.
 
 ### Customizing window's title appearance
 
-You can enable title drawing by setting `showsTitle` property to `YES`. For NSDocument based apps, you can enable drawing the document proxy icon by setting `showsProxyIcon` property to `YES`. You can adjust appearance using `titleTextColor`, `inactiveTitleTextColor`, `titleTextShadow`, and `inactiveTitleTextShadow` properties. Also, you can enable title drawing in fullscreen by setting `showsTitleInFullscreen` property to `YES`.
+You can enable title drawing by setting `showsTitle` property to `YES`. For NSDocument based apps, you can enable drawing the document proxy icon by setting `showsDocumentProxyIcon` property to `YES`. You can adjust appearance using `titleTextColor`, `inactiveTitleTextColor`, `titleTextShadow`, and `inactiveTitleTextShadow` properties. Also, you can enable title drawing in fullscreen by setting `showsTitleInFullscreen` property to `YES`.
 
 ### Using your own drawing code
 


### PR DESCRIPTION
I added a simple property that handles drawing of the document proxy icon in NSDoc apps. In your current implementation the proxy icon was still drawn if you set 'showsTitle' to NO. Drawing of the proxy icon needs to be enabled by setting 'showsProxyIcon' to YES, the default value is NO for now. Thought it would make more sense that way. Documentation is updated as well. You're welcome :)
