### PR TITLE
Add backward compatibility to Mac OS 10.6

### DIFF
--- a/INWindowButton.m
+++ b/INWindowButton.m
@@ -190,8 +190,10 @@ NSString *const kINWindowButtonGroupDefault = @"com.indragie.inappstorewindow.de
     if (self.window) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidBecomeKeyNotification object:self.window];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidResignKeyNotification object:self.window];
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillEnterFullScreenNotification object:self.window];
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillExitFullScreenNotification object:self.window];
+        if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillEnterFullScreenNotification object:self.window];
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillExitFullScreenNotification object:self.window];
+        }
     }
     if (newWindow != nil) {
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -202,14 +204,16 @@ NSString *const kINWindowButtonGroupDefault = @"com.indragie.inappstorewindow.de
                                                  selector:@selector(windowDidChangeFocus:)
                                                      name:NSWindowDidResignKeyNotification
                                                    object:newWindow];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(windowWillEnterFullScreen:)
-                                                     name:NSWindowWillEnterFullScreenNotification
-                                                   object:newWindow];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(windowWillExitFullScreen:)
-                                                     name:NSWindowWillExitFullScreenNotification
-                                                   object:newWindow];
+        if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)]) {
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(windowWillEnterFullScreen:)
+                                                         name:NSWindowWillEnterFullScreenNotification
+                                                       object:newWindow];
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(windowWillExitFullScreen:)
+                                                         name:NSWindowWillExitFullScreenNotification
+                                                       object:newWindow];
+        }
     }
 }
 


### PR DESCRIPTION
I adopted INAppStoreWindow in my application (targeting Mac OX >= 10.6) and I found it crashes on 10.6 so I added code to prevent crashes caused by 'Full Screen' related feature. 

It would be great that if you set main window's 'Full Screen' property to 'Unsupported' in the XIBs and add some code(suggested  below) to make sure it runs well on 10.6. (I couldn't make direct changes on XIB because I currently use Xcode with old version)

[suggested code]

// this can be added any init code for the main window
if ([self.window respondsToSelector:@selector(toggleFullScreen:)]) {
        self.window.collectionBehavior &= !NSWindowCollectionBehaviorFullScreenAuxiliary;
        self.window.collectionBehavior |= NSWindowCollectionBehaviorFullScreenPrimary;
    }
