### PR TITLE
Added mouse drag detection threshold.

### DIFF
--- a/INAppStoreWindow.h
+++ b/INAppStoreWindow.h
@@ -104,6 +104,11 @@
  */
 @property (nonatomic) CGFloat trafficLightSeparation;
 
+/**
+ Ammount of points in any direction above which window will be allowed to reposition. Higher value means coarser movements but much reduced CPU overload. Defaults to 1.
+ */
+@property (nonatomic) CGFloat mouseDragDetectionThreshold;
+
 /** Adjust the visibility of the window's title. If `YES`, title will be shown even if titleBarDrawingBlock is set.
  To draw title on your own, set this property to `NO` and draw title inside titleBarDrawingBlock. */
 @property (nonatomic) BOOL showsTitle;


### PR DESCRIPTION
Hey!

I've had noticeable CPU issues on an app I'm working on when using INAppStoreWindow. Measuring in Instruments pointed to `[NSWindow setFrameOrigin:]` call within `[INTitlebarContainer mouseDragged:]` as taking ~70% while parent while loop ~30%.

With this commit, the situation is considerably better on CPU load. `setFrameOrigin:` is only called when drag occurs on container view.
