### PR TITLE
Disabled window buttons now respect their style when window is not focused

### DIFF
--- a/INWindowButton.m
+++ b/INWindowButton.m
@@ -274,18 +274,19 @@ NSString *const kINWindowButtonGroupDefault = @"com.indragie.inappstorewindow.de
 }
 
 - (void)updateImage {
-    if ([self isEnabled]) {
+    if ([self.window isKeyWindow]) {
         [self updateActiveImage];
-    } else {
-        self.image = self.inactiveImage;
+    }
+    else {
+        self.image = self.activeNotKeyWindowImage;
     }
 }
 
 - (void)updateActiveImage {
-    if ([self.window isKeyWindow]) {
+    if ([self isEnabled]) {
         self.image = self.activeImage;
     } else {
-        self.image = self.activeNotKeyWindowImage;
+        self.image = self.inactiveImage;
     }
 }
 


### PR DESCRIPTION
Comparing to what happens with vanilla Cocoa windows, this seems to be the correct behaviour. Window button styles should respect the inactive window style even when disabled.
