### PR TITLE
Adjust the window frame when setTitleBarHeight is called.

### DIFF
--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -658,8 +658,15 @@ NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSCol
 - (void)setTitleBarHeight:(CGFloat)newTitleBarHeight
 {
 	if (_titleBarHeight != newTitleBarHeight) {
+		NSRect windowFrame = self.frame;
+		windowFrame.origin.y -= newTitleBarHeight - _titleBarHeight;
+		windowFrame.size.height += newTitleBarHeight - _titleBarHeight;
+
 		_cachedTitleBarHeight = newTitleBarHeight;
 		_titleBarHeight = _cachedTitleBarHeight;
+
+		[self setFrame:windowFrame display:YES];
+
 		[self _layoutTrafficLightsAndContent];
 		[self _displayWindowAndTitlebar];
 


### PR DESCRIPTION
This has the effect that the content view of the window is not resized
when changing the height of the title bar, which is consistent with how
NSToolbars in the title bar work when changing their visibility and
size.
