### PR TITLE
Fix metrics and drawing when NSToolbars are used.

### DIFF
--- a/Extensions/INTitlebarView+CoreUIRendering.m
+++ b/Extensions/INTitlebarView+CoreUIRendering.m
@@ -54,8 +54,8 @@ static _CUIDraw CUIDraw = 0;
     NSDictionary *options = @{@"widget": @"kCUIWidgetWindowFrame",
                               @"state": (window.isMainWindow ? @"normal" : @"inactive"),
                               @"windowtype": @"regularwin",
-                              @"kCUIWindowFrameUnifiedTitleBarHeightKey": @(window.titleBarHeight),
-                              @"kCUIWindowFrameDrawTitleSeparatorKey": @(window.showsBaselineSeparator),
+                              @"kCUIWindowFrameUnifiedTitleBarHeightKey": @(window.titleBarHeight + window.toolbarHeight),
+                              @"kCUIWindowFrameDrawTitleSeparatorKey": @(window.toolbar ? window.toolbar.showsBaselineSeparator : window.showsBaselineSeparator),
                               @"is.flipped": @(self.isFlipped)};
     CUIDraw([NSWindow coreUIRenderer], drawingRect, [[NSGraphicsContext currentContext] graphicsPort], (__bridge CFDictionaryRef) options, nil);
 }


### PR DESCRIPTION
INAppStoreWindow now forces the title bar height to the standard
minimum when used in conjunction with an NSToolbar, as this is the only
configuration that makes sense.

Painting now also takes into account the toolbar height.
