### PR TITLE
Fix bug causing CoreUI not to draw the title separator.

### DIFF
--- a/Extensions/INTitlebarView+CoreUIRendering.m
+++ b/Extensions/INTitlebarView+CoreUIRendering.m
@@ -55,7 +55,7 @@ static _CUIDraw CUIDraw = 0;
                               @"state": (window.isMainWindow ? @"normal" : @"inactive"),
                               @"windowtype": @"regularwin",
                               @"kCUIWindowFrameUnifiedTitleBarHeightKey": @(window.titleBarHeight + window.toolbarHeight),
-                              @"kCUIWindowFrameDrawTitleSeparatorKey": @(window.toolbar ? window.toolbar.showsBaselineSeparator : window.showsBaselineSeparator),
+                              @"kCUIWindowFrameDrawTitleSeparatorKey": window.toolbar ? @(window.toolbar.showsBaselineSeparator) : @(window.showsBaselineSeparator),
                               @"is.flipped": @(self.isFlipped)};
     CUIDraw([NSWindow coreUIRenderer], drawingRect, [[NSGraphicsContext currentContext] graphicsPort], (__bridge CFDictionaryRef) options, nil);
 }


### PR DESCRIPTION
This is bizarre. Should be a compiler warning.
