### PR TITLE
fix missing window buttons in full screen mode on Yosemite

### DIFF
--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -1166,9 +1166,14 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 		minimizeFrame.origin.y = NSMaxY(zoomFrame) + self.trafficLightSeparation - 2.f;
 		closeFrame.origin.y = NSMaxY(minimizeFrame) + self.trafficLightSeparation - 2.f;
 	}
-	close.frame = closeFrame;
-	minimize.frame = minimizeFrame;
-	zoom.frame = zoomFrame;
+
+	// On Yosemite, if the window is in full screen mode, the window buttons are in a different window
+	// and should not be set here.
+	if ([[close superview] superview] == nil) {
+		close.frame = closeFrame;
+		minimize.frame = minimizeFrame;
+		zoom.frame = zoomFrame;
+	}
 
 	NSButton *docIconButton = [self standardWindowButton:NSWindowDocumentIconButton];
 	if (docIconButton) {


### PR DESCRIPTION
On Yosemite, when the window is in full screen mode, the window buttons are on a different window other than the INAppStoreWindow. If we set the frames of window buttons, they disappear from the floating titlebar when the mouse is moved up to the menu.
The patch fixes the issue by checking if the window buttons are in a normal window.
