### PR TITLE
Issue 180 - On Yosemite traffic lights in full screen are missing

### DIFF
--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -1130,7 +1130,11 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 	CGFloat buttonOrigin = 0.0;
 	if (!self.verticalTrafficLightButtons) {
 		if (self.centerTrafficLightButtons) {
-			buttonOrigin = round(NSMidY(titleBarFrame) - INMidHeight(closeFrame));
+			if (INRunningYosemite() && self.styleMask & NSFullScreenWindowMask) {
+				buttonOrigin = round(self._minimumTitlebarHeight * 0.5 - INMidHeight(closeFrame));
+			} else {
+				buttonOrigin = round(NSMidY(titleBarFrame) - INMidHeight(closeFrame));
+			}
 		} else {
 			buttonOrigin = NSMaxY(titleBarFrame) - NSHeight(closeFrame) - self.trafficLightButtonsTopMargin;
 		}


### PR DESCRIPTION
If we are full screen then move them where we expect them to be.
