### PR TITLE
Replaced the deprecated API (maintaining compatibility)

### DIFF
--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -153,7 +153,8 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 
 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: 0]];
+	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer
+																					 options: NSDataBase64DecodingIgnoreUnknownCharacters]];
 #else
 	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer]];
 #endif
@@ -161,7 +162,8 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 		[image addRepresentation:rep];
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: 0]]];
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x
+																											options: NSDataBase64DecodingIgnoreUnknownCharacters]]];
 #else
 		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x]]];
 #endif

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -149,11 +149,22 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 
 	static dispatch_once_t oncePredicate;
 	dispatch_once(&oncePredicate, ^{
-		NSBitmapImageRep *rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer]];
+	NSBitmapImageRep *rep = nil;
+
+// initWithBase64EncodedString:options: is available in OS X v10.9 and later
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
+	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: 0]];
+#else
+	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer]];
+#endif
 		NSImage *image = [[NSImage alloc] initWithSize:rep.size];
 		[image addRepresentation:rep];
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x]]];
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: 0]]];
+#else
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x]]];
+#endif
 		noiseColor = [NSColor colorWithPatternImage:image];
 	});
 

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -155,7 +155,7 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 	#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
 		layerInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters];
 	#else
-		data = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
+		layerInBase64 = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
 	#endif
 		rep = [[NSBitmapImageRep alloc] initWithData: layerInBase64];
 

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -151,24 +151,24 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 	dispatch_once(&oncePredicate, ^{
 		NSBitmapImageRep *rep = nil;
 
-		NSData* layerInBase64 = nil;
+		NSData *layerInBase64 = nil;
 	#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
-		layerInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters];
+		layerInBase64 = [[NSData alloc] initWithBase64EncodedString:INWindowBackgroundPatternOverlayLayer options:NSDataBase64DecodingIgnoreUnknownCharacters];
 	#else
-		layerInBase64 = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
+		layerInBase64 = [[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer];
 	#endif
-		rep = [[NSBitmapImageRep alloc] initWithData: layerInBase64];
+		rep = [[NSBitmapImageRep alloc] initWithData:layerInBase64];
 
 		NSImage *image = [[NSImage alloc] initWithSize:rep.size];
 		[image addRepresentation:rep];
 
-		NSData* layer2xInBase64 = nil;
+		NSData *layer2xInBase64 = nil;
 	#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9 // Same as above
-		layer2xInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters];
+		layer2xInBase64 = [[NSData alloc] initWithBase64EncodedString:INWindowBackgroundPatternOverlayLayer2x options:NSDataBase64DecodingIgnoreUnknownCharacters];
 	#else
 		layer2xInBase64 = [[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x];
 	#endif
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData: layer2xInBase64]];
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:layer2xInBase64]];
 
 		noiseColor = [NSColor colorWithPatternImage:image];
 	});

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -151,21 +151,28 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 	dispatch_once(&oncePredicate, ^{
 	NSBitmapImageRep *rep = nil;
 
+	NSData* layerInBase64 = nil;
 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters]];
+	layerInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters];
 #else
-	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer]];
+	data = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
 #endif
-		NSImage *image = [[NSImage alloc] initWithSize:rep.size];
-		[image addRepresentation:rep];
+	rep = [[NSBitmapImageRep alloc] initWithData: layerInBase64];
 
+	NSImage *image = [[NSImage alloc] initWithSize:rep.size];
+	[image addRepresentation:rep];
+
+	NSData* layer2xInBase64 = nil;
+// Same as above
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters]]];
+	layer2xInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters];
 #else
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x]]];
+	layer2xInBase64 = [[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x];
 #endif
-		noiseColor = [NSColor colorWithPatternImage:image];
+	[image addRepresentation:[[NSBitmapImageRep alloc] initWithData: layer2xInBase64]];
+
+	noiseColor = [NSColor colorWithPatternImage:image];
 	});
 
 	return noiseColor;

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -149,30 +149,28 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 
 	static dispatch_once_t oncePredicate;
 	dispatch_once(&oncePredicate, ^{
-	NSBitmapImageRep *rep = nil;
+		NSBitmapImageRep *rep = nil;
 
-	NSData* layerInBase64 = nil;
-// initWithBase64EncodedString:options: is available in OS X v10.9 and later
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-	layerInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters];
-#else
-	data = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
-#endif
-	rep = [[NSBitmapImageRep alloc] initWithData: layerInBase64];
+		NSData* layerInBase64 = nil;
+	#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
+		layerInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters];
+	#else
+		data = [[ NSData alloc] initWithBase64Encoding: INWindowBackgroundPatternOverlayLayer];
+	#endif
+		rep = [[NSBitmapImageRep alloc] initWithData: layerInBase64];
 
-	NSImage *image = [[NSImage alloc] initWithSize:rep.size];
-	[image addRepresentation:rep];
+		NSImage *image = [[NSImage alloc] initWithSize:rep.size];
+		[image addRepresentation:rep];
 
-	NSData* layer2xInBase64 = nil;
-// Same as above
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-	layer2xInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters];
-#else
-	layer2xInBase64 = [[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x];
-#endif
-	[image addRepresentation:[[NSBitmapImageRep alloc] initWithData: layer2xInBase64]];
+		NSData* layer2xInBase64 = nil;
+	#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9 // Same as above
+		layer2xInBase64 = [[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters];
+	#else
+		layer2xInBase64 = [[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x];
+	#endif
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData: layer2xInBase64]];
 
-	noiseColor = [NSColor colorWithPatternImage:image];
+		noiseColor = [NSColor colorWithPatternImage:image];
 	});
 
 	return noiseColor;

--- a/INAppStoreWindow/INAppStoreWindow.m
+++ b/INAppStoreWindow/INAppStoreWindow.m
@@ -153,8 +153,7 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 
 // initWithBase64EncodedString:options: is available in OS X v10.9 and later
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer
-																					 options: NSDataBase64DecodingIgnoreUnknownCharacters]];
+	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer options: NSDataBase64DecodingIgnoreUnknownCharacters]];
 #else
 	rep = [[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer]];
 #endif
@@ -162,8 +161,7 @@ NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
 		[image addRepresentation:rep];
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_9
-		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x
-																											options: NSDataBase64DecodingIgnoreUnknownCharacters]]];
+		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64EncodedString: INWindowBackgroundPatternOverlayLayer2x options: NSDataBase64DecodingIgnoreUnknownCharacters]]];
 #else
 		[image addRepresentation:[[NSBitmapImageRep alloc] initWithData:[[NSData alloc] initWithBase64Encoding:INWindowBackgroundPatternOverlayLayer2x]]];
 #endif


### PR DESCRIPTION
`-initWithBase64Encoding:` [has been deprecated in OS X v10.9 and later](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/#//apple_ref/occ/instm/NSData/initWithBase64Encoding:), so when we compile source code in OS X v10.9 and later, there will be some compile-time warnings:

![screen shot 2015-04-02 at 1 51 24](https://cloud.githubusercontent.com/assets/4256649/6947638/36be8e14-d8db-11e4-9522-aa1542310128.png)

I replaced them with `initWithBase64EncodedString:options:` that is available in OS X 10.9 and later. And for the compatibility considerations, I maintained the deprecated method.

For details, please see `Commits`.
